### PR TITLE
Strict Standards Fix: Non-static method should not be called statically

### DIFF
--- a/core/common/FinanceData.class.php
+++ b/core/common/FinanceData.class.php
@@ -146,7 +146,7 @@ class FinanceData extends CodonData {
      * @param mixed $timestamp
      * @return
      */
-    public function setExpensesforMonth($timestamp) {
+    public static function setExpensesforMonth($timestamp) {
         
         $all_expenses = self::getAllExpenses();
         


### PR DESCRIPTION
FinanceData::setExpensesforMonth() should not be called statically
